### PR TITLE
addon: enable netipmid (phosphor-ipmi-net)

### DIFF
--- a/recipes-phosphor/image/obmc-phosphor-image.bbappend
+++ b/recipes-phosphor/image/obmc-phosphor-image.bbappend
@@ -80,5 +80,5 @@ do_generate_static() {
 	ln -sf rwfs.${OVERLAY_BASETYPE} ${IMGDEPLOYDIR}/image-rwfs
 }
 
-IMAGE_INSTALL_append = "obmc-ikvm phosphor-webui phosphor-ipmi-host\
+IMAGE_INSTALL_append = "obmc-ikvm phosphor-webui phosphor-ipmi-net phosphor-ipmi-host\
                         "


### PR DESCRIPTION
1. Verfied with Supermicro MBD-X9SCL-F-0.
2. Test command: "sudo ipmiutil sol -N ${POLEG_IP}" -U admin -P 0penBmc -J 3 -V 4 -a".